### PR TITLE
Bugfix for the goproctl script

### DIFF
--- a/scripts/goproctl
+++ b/scripts/goproctl
@@ -16,6 +16,8 @@ parser.add_argument(
     'param', help='the parameter to be changed or "status" for status')
 parser.add_argument(
     'value', help='the value to set the parameter to')
+parser.add_argument(
+    '--interface', help='the wifi interface to use', required=False)
 args = parser.parse_args()
 
 # set up camera and network adapters


### PR DESCRIPTION
Adds the --interface option to the goproctl script to allow interface
to be specified.
Fixes a bug introduced in 92db6caf causing goproctl to fail because
args.interface does not exist.
